### PR TITLE
release_0.1.1: Re-orders archives/templates; fixes sudoers creation.

### DIFF
--- a/lib/danarchy_deploy.rb
+++ b/lib/danarchy_deploy.rb
@@ -27,7 +27,8 @@ module DanarchyDeploy
 
       deployment[:last_deploy] = DateTime.now.strftime("%Y/%m/%d %H:%M:%S")
       puts "\nFinished Local Deployment at #{deployment[:last_deploy]}!"
-      File.write(options[:deploy_file], deployment.to_json) if options[:deploy_file].end_with?('.json')
+      File.write(options[:deploy_file],
+                 JSON.pretty_generate(deployment) if options[:deploy_file].end_with?('.json')
       File.write(options[:deploy_file], deployment.to_yaml) if options[:deploy_file].end_with?('.yaml')
       deployment
     end

--- a/lib/danarchy_deploy/services.rb
+++ b/lib/danarchy_deploy/services.rb
@@ -7,15 +7,15 @@ module DanarchyDeploy
       deployment[:services].each do |service, params|
         puts "Configuring service: #{service}"
 
-        if params[:templates] && !params[:templates].empty?
-          puts " > COnfiguring templates for #{service}"
-          DanarchyDeploy::Templater.new(params[:templates], options)
-        end
-
         if params[:archives] && !params[:archives].empty?
           puts "\n" + self.name
           puts " > Deploying archives for #{service}"
           DanarchyDeploy::Archiver.new(params[:archives], options)
+        end
+
+        if params[:templates] && !params[:templates].empty?
+          puts " > COnfiguring templates for #{service}"
+          DanarchyDeploy::Templater.new(params[:templates], options)
         end
       end
 

--- a/lib/danarchy_deploy/users.rb
+++ b/lib/danarchy_deploy/users.rb
@@ -123,7 +123,7 @@ module DanarchyDeploy
 
     def self.sudoer(user)
       sudoer_file = '/etc/sudoers.d/danarchy_deploy-' + user[:username]
-      File.open(sudoer_file, 'r+') do |f|
+      File.open(sudoer_file, 'a+') do |f|
         if !f.read.include?(user[:sudoer])
           puts "   |+ Added: '#{user[:sudoer]}'"
           f.puts user[:sudoer]

--- a/lib/danarchy_deploy/version.rb
+++ b/lib/danarchy_deploy/version.rb
@@ -1,3 +1,3 @@
 module DanarchyDeploy
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
- Re-order archive extraction and template creation so that written templates aren't overwritten by archive data.
- Fixes user sudoers.d file creation; a+ append instead of r+ read-write (expects file to exist already).
- Cleans up package handling for Gentoo and also changes --usepkg to --buildpkg if hostname begins with 'image' or 'template' for binary creation during image builds.