### PR TITLE
patch_0.1.4: Keeps sudoers.d/ file root owned.

### DIFF
--- a/lib/danarchy_deploy/users.rb
+++ b/lib/danarchy_deploy/users.rb
@@ -118,6 +118,7 @@ module DanarchyDeploy
           end
         end
 
+        f.chown(user[:uid], user[:gid])
         f.close
       end
     end
@@ -132,7 +133,6 @@ module DanarchyDeploy
           puts '   - No change needed'
         end
 
-        f.chown(user[:uid], user[:gid])
         f.close
       end
     end

--- a/lib/danarchy_deploy/version.rb
+++ b/lib/danarchy_deploy/version.rb
@@ -1,3 +1,3 @@
 module DanarchyDeploy
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
f.chown line was in sudoers method rather than authorized_keys; this switches its location.