### PR TITLE
patch_0.2.2: correctly apply mongodb open file limit

### DIFF
--- a/lib/danarchy_deploy/services/mongodb.rb
+++ b/lib/danarchy_deploy/services/mongodb.rb
@@ -59,7 +59,7 @@ module DanarchyDeploy
       end
 
       def self.generate_mongodb_conf
-        if ! File.readlines('/etc/security/limits.conf').grep(/mongodb/)
+        if File.readlines('/etc/security/limits.conf').grep(/mongodb/).empty?
           entry =  'mongodb         soft     nofile          32000'
           entry += 'mongodb         hard     nofile          64000'
           File.open('/etc/security/limits.conf', 'a+') do |f|

--- a/lib/danarchy_deploy/version.rb
+++ b/lib/danarchy_deploy/version.rb
@@ -1,3 +1,3 @@
 module DanarchyDeploy
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
patch_0.2.2: Fix MongoDB so it correctly applies security limits file count